### PR TITLE
Add Code of Conduct document

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,5 +1,31 @@
 # The Things Network Community Code of Conduct
 
+## Community Values
+
+These are the values to which people in community of The Things Stack should aspire.
+
+* Be friendly and welcoming.
+* Be patient.
+  - Remember that people have varying communication styles and that not everyone is using their native language. Meaning and tone can be lost in translation.
+* Be thoughtful.
+  - Productive communication requires effort. Think about how your words will be interpreted.
+  - Remember that sometimes it is best to refrain entirely from commenting.
+* Be respectful.
+  - In particular, respect differences of opinion.
+* Be charitable.
+  - Interpret the arguments of others in good faith, do not seek to disagree.
+  - When we do disagree, try to understand why.
+* Be constructive.
+  - Avoid derailing: stay on topic; if you want to talk about something else, start a new conversation.
+  - Avoid unconstructive criticism: don't merely decry the current state of affairs; offer -- or at least solicit -- suggestions as to how things may be improved.
+  - Avoid snarking (pithy, unproductive, sniping comments).
+  - Avoid discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+  - Avoid microaggressions (brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group).
+* Be responsible.
+  - What you say and do matters. Take responsibility for your words and actions, including their consequences, whether intended or otherwise.
+
+People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of all parties to de-escalate conflict when it arises.
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# The Things Network Community Code of Conduct
 
 ## Our Pledge
 
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+community@thethingsnetwork.org.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -2,7 +2,7 @@
 
 ## Community Values
 
-These are the values to which people in community of The Things Stack should aspire.
+These are the values to which people in community of The Things Network should aspire.
 
 * Be friendly and welcoming.
 * Be patient.

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -79,7 +79,9 @@ decisions when appropriate.
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
 Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
+posting via an official social media account, posting via a social media account
+associated with a local community, posting via other social media accounts that
+use (a version of) the logo of The Things Network, or acting as an appointed
 representative at an online or offline event.
 
 ## Enforcement

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -140,19 +140,9 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Our community values were adapted from the Gopher values of the [Go community code of conduct](https://golang.org/conduct).
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
-at [https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).


### PR DESCRIPTION
We've been discussing for years that we should add a formal Code of Conduct that we can use in our different "community spaces" such as our GitHub repositories, the Forum, Slack channels, Conferences, local Meetups, etc.

In this pull request, I'm adding a starting point for our Code of Conduct. 

Instead of writing this from scratch, I thought it would best to start with [The Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), which is already widely used in other communities.

In addition to the Contributor Covenant, I adapted the ["Values" section of the Go Community Code of Conduct](https://golang.org/conduct). I decided to keep them as separate sections, so that we stay as close as possible to the original Contributor Covenant, but we can also decide to merge these values into the "Our Standards" section of the Contributor Covenant.

---

To be discussed in this Pull Request:

- Is the Manifesto repository the right place for this?
- Is the Contributor Covenant a good starting point?
- Is the **Community Values** section a good summary of how we want to interact with/in the community?
- Do we want to make any adaptations at this point?
- Specifically: Do we want to merge the "Community Values" section into "Our Standards" or keep them separate?